### PR TITLE
Ch4, Ex.1: Explicitly name the scale argument in stats.expon()

### DIFF
--- a/Chapter4_TheGreatestTheoremNeverTold/LawOfLargeNumbers.ipynb
+++ b/Chapter4_TheGreatestTheoremNeverTold/LawOfLargeNumbers.ipynb
@@ -1038,7 +1038,7 @@
      "input": [
       "## Enter code here\n",
       "import scipy.stats as stats\n",
-      "exp = stats.expon( 4 )\n",
+      "exp = stats.expon( scale=4 )\n",
       "N = 1e5\n",
       "X = exp.rvs( N )\n",
       "## ..."


### PR DESCRIPTION
In scipy 0.12.0, the first unnamed argument to stats.expon() becomes the location of the distribution. As such, the starter code gives the reader an Exp(1) distribution starting at x=4.
