### PR TITLE
Fix error in posterior graphs for text data

### DIFF
--- a/Chapter1_Introduction/Chapter1_Introduction.ipynb
+++ b/Chapter1_Introduction/Chapter1_Introduction.ipynb
@@ -745,7 +745,7 @@
       "plt.legend(loc = \"upper left\")\n",
       "plt.title(r\"Posterior distributions of the variables $\\lambda_1,\\;\\lambda_2,\\;\\tau$\")\n",
       "plt.xlim([15,30])\n",
-      "plt.xlabel(\"$\\lambda_2$ value\")\n",
+      "plt.xlabel(\"$\\lambda_1$ value\")\n",
       "plt.ylabel(\"probability\")\n",
       "\n",
       "ax = plt.subplot(312)\n",


### PR DESCRIPTION
Label on first x-axis was wrong. Both of the graphs were labeled with lambda_2.

![screen shot 2013-07-01 at 5 19 43 pm](https://f.cloud.github.com/assets/684965/733660/cf888a66-e2a4-11e2-93aa-719f5d0b889e.png)
