### PR TITLE
Fix wrong reference to p_B instead of delta

### DIFF
--- a/Chapter2_MorePyMC/MorePyMC.ipynb
+++ b/Chapter2_MorePyMC/MorePyMC.ipynb
@@ -1030,7 +1030,7 @@
      "source": [
       "Notice that as a result of `N_B < N_A`, i.e. we have less data from site B, our posterior distribution of $p_B$ is fatter, implying we are less certain about the true value of $p_B$ than we are of $p_A$.  \n",
       "\n",
-      "With respect to the posterior distribution of $\\text{delta}$, we can see that the majority of the distribution is above $p_B =0$, implying there site A's response is likely better than site B's response. The probability this inference is incorrect is easily computable:"
+      "With respect to the posterior distribution of $\\text{delta}$, we can see that the majority of the distribution is above $\\text{delta}=0$ =0$, implying there site A's response is likely better than site B's response. The probability this inference is incorrect is easily computable:"
      ]
     },
     {


### PR DESCRIPTION
I've made a small fix: in the text there was a $p_B = 0$ where it should be $\text{delta} = 0$.

This is the first time I do a pull request so bear with me if I did something wrong ;).
