### PR TITLE
Histogram was not visible due to incorrect ylims.

### DIFF
--- a/Chapter3_MCMC/IntroMCMC.ipynb
+++ b/Chapter3_MCMC/IntroMCMC.ipynb
@@ -338,6 +338,7 @@
       "\n",
       "hist(data, bins=20,  color=\"k\", histtype=\"stepfilled\", alpha=0.8)\n",
       "plt.title(\"Histogram of the dataset\")\n",
+      "plt.ylim([0, None])\n",
       "print data[:10], \"...\""
      ],
      "language": "python",


### PR DESCRIPTION
A quick fix for a non-visible histogram due to incorrect automatic setting of y-limits.
(Versions: ipython: git master branch, matplotlib 1.2.1)
