### PR TITLE
I found some typo in Chapter2_MorePyMC/MorePyMC.ipynb.

### DIFF
--- a/Chapter2_MorePyMC/MorePyMC.ipynb
+++ b/Chapter2_MorePyMC/MorePyMC.ipynb
@@ -150,7 +150,7 @@
       "\n",
       "`some_variable = mc.DiscreteUniform(\"discrete_uni_var\", 0, 4)`\n",
       "\n",
-      "where 0, 4 are the `DiscreteUniform`-specific upper and lower bound on the random variable. The [PyMC docs](http://pymc-devs.github.com/pymc/distributions.html) contain the specific parameters for stochastic variables. (Or use `??` if you are using IPython!)\n",
+      "where 0, 4 are the `DiscreteUniform`-specific lower and upper bound on the random variable. The [PyMC docs](http://pymc-devs.github.com/pymc/distributions.html) contain the specific parameters for stochastic variables. (Or use `??` if you are using IPython!)\n",
       "\n",
       "The `name` attribute is used to retrieve the posterior distribution later in the analysis, so it is best to use a descriptive name. Typically, I use the Python variable's name as the name.\n",
       "\n",
@@ -1030,7 +1030,7 @@
      "source": [
       "Notice that as a result of `N_B < N_A`, i.e. we have less data from site B, our posterior distribution of $p_B$ is fatter, implying we are less certain about the true value of $p_B$ than we are of $p_A$.  \n",
       "\n",
-      "With respect to the posterior distribution of $\\text{delta}$, we can see that the majority of the distribution is above $\\text{delta}=0$ =0$, implying there site A's response is likely better than site B's response. The probability this inference is incorrect is easily computable:"
+      "With respect to the posterior distribution of $\\text{delta}$, we can see that the majority of the distribution is above $\\text{delta}=0$, implying there site A's response is likely better than site B's response. The probability this inference is incorrect is easily computable:"
      ]
     },
     {
@@ -1762,7 +1762,7 @@
      "source": [
       "### Normal distributions\n",
       "\n",
-      "A Normal random variable, denoted $X \\sim N(\\mu, 1/\\tau)$, has a distribution with two parameters: the mean, $\\mu$, and the *precision*, $\\tau$. Those familiar with the Normal distribution already have probably seen $\\sigma^2$ instead of $\\tau$. They are in fact reciprocals of each other. The change was motivated by simpler mathematical analysis and is an artifact of older Bayesian methods. Just remember: The smaller $\\tau$, the larger the spread of the distribution (i.e. we are more uncertain); the larger $\\tau$, the tighter the distribution (i.e. we are more certain). Regardless, $\\tau$ is always positive. \n",
+      "A Normal random variable, denoted $X \\sim N(\\mu, 1/\\tau)$, has a distribution with two parameters: the mean, $\\mu$, and the *precision*, $\\tau$. Those familiar with the Normal distribution already have probably seen $\\sigma^2$ instead of $\\tau^{-1}$. They are in fact reciprocals of each other. The change was motivated by simpler mathematical analysis and is an artifact of older Bayesian methods. Just remember: The smaller $\\tau$, the larger the spread of the distribution (i.e. we are more uncertain); the larger $\\tau$, the tighter the distribution (i.e. we are more certain). Regardless, $\\tau$ is always positive. \n",
       "\n",
       "The probability density function of a $N( \\mu, 1/\\tau)$ random variable is:\n",
       "\n",


### PR DESCRIPTION
1. In the section [A and B Together],
   "$\text{delta}=0$ =0$" should be "$\text{delta}=0$"
2. In the section [Initializing Stochastic variables],
   "where 0, 4 are the DiscreteUniform-specific upper and lower"
   should be "where 0, 4 are the DiscreteUniform specific lower and upper"
3. In the section [Normal distributions],
   "$\sigma^{2}$ instead of $\tau$" should be "$\sigma^{2}$ instead of $\tau^{-1}$
