### PR TITLE
Include bold and oblique font files for sharper and more readable text

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -6,18 +6,18 @@
     @font-face {
         font-family: "Computer Modern";
         font-weight: bold;
-        src: url('http://ctan.mirror.rafal.ca/fonts/cm-unicode/fonts/otf/cmunsx.otf');
+        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsx.otf');
     }
     @font-face {
         font-family: "Computer Modern";
         font-style: oblique;
-        src: url('http://ctan.mirror.rafal.ca/fonts/cm-unicode/fonts/otf/cmunsi.otf');
+        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsi.otf');
     }
     @font-face {
         font-family: "Computer Modern";
         font-weight: bold;
         font-style: oblique;
-        src: url('http://ctan.mirror.rafal.ca/fonts/cm-unicode/fonts/otf/cmunso.otf');
+        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunso.otf');
     }
     div.cell{
         width:800px;


### PR DESCRIPTION
Only the "normal" variation of Computer Modern Sans is included in the CSS file, so the browser simulates (poorly) the bold, oblique, and bold oblique versions of the font. Including these styles makes the bold more distinct from the regular text, and makes the text sharper in general.

I have hotlinked to the tex mirror but I anticipate that someone with write access to the rackspace CDN (@rgbkrk?) will want to upload the appropriate files there.

Before (Chrome, Mac OS):
![before](https://f.cloud.github.com/assets/46173/2221807/a77473ca-9a5d-11e3-8521-49dfb050700c.png)

After:
![after](https://f.cloud.github.com/assets/46173/2221808/aa8ea558-9a5d-11e3-9b83-b782caa4ca7a.png)
