### PR TITLE
minor typos

### DIFF
--- a/Chapter6_Priorities/Priors.ipynb
+++ b/Chapter6_Priorities/Priors.ipynb
@@ -881,7 +881,7 @@
       "    \n",
       "   1. Sample a random variable $X_b$ from the prior of bandit $b$, for all $b$.\n",
       "   2. Select the bandit with largest sample, i.e. select bandit $B = \\text{argmax}\\;\\; X_b$.\n",
-      "   3. Observe the result,$R \\sim f_{y_a}$, of pulling bandit $B$, and update your prior on bandit $B$.\n",
+      "   3. Observe the result,$R \\sim f_{y_b}$, of pulling bandit $B$, and update your prior on bandit $B$.\n",
       "   4. Return to 1\n",
       "\n",
       "   The issue is in the sampling of $X_b$ drawing phase. With Beta priors and Bernoulli observations, we have a Beta posterior &mdash; this is easy to sample from. But now, with arbitrary distributions $f$, we have a non-trivial posterior. Sampling from these can be difficult.\n",
@@ -890,14 +890,14 @@
       "\n",
       "His proposal is to consider each comment as a Bandit, with the number of pulls equal to the number of votes cast, and number of rewards as the number of upvotes, hence creating a $\\text{Beta}(1+U,1+D)$ posterior. As visitors visit the page, samples are drawn from each bandit/comment, but instead of displaying the comment with the $\\max$ sample, the comments are ranked according to the ranking of their respective samples. From J. Neufeld's blog [7]:\n",
       "\n",
-      "   > [The] resulting ranking algorithm is quite straightforward, each new time the comments page is loaded, the score for each comment is sampled from a $\\text{Beta}(1+U,1+D)$, comments are then ranked by this score in descending order... This randomization has a unique benefit in that even untouched comments $(U=1,D=0)$ have some chance of being seen even in threads with 5000+ comments (something that is not happening now), but, at the same time, the user is not likely to be inundated with rating these new comments. "
+      "   > [The] resulting ranking algorithm is quite straightforward, each new time the comments page is loaded, the score for each comment is sampled from a $\\text{Beta}(1+U,1+D)$, comments are then ranked by this score in descending order... This randomization has a unique benefit in that even untouched comments $(U=0,D=0)$ have some chance of being seen even in threads with 5000+ comments (something that is not happening now), but, at the same time, the user is not likely to be inundated with rating these new comments. "
      ]
     },
     {
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Just for fun, though the colors explode, we watch the Bayesian Bandit algorithm learn 15 different options. "
+      "Just for fun, though the colors explode, we watch the Bayesian Bandit algorithm learn 35 different options. "
      ]
     },
     {


### PR DESCRIPTION
There are 3 minor typos in this pull.
I am not sure about one of them: "untouched comments (U=1,D=0)" which I think should be "untouched comments (U=0,D=0)"
