### PR TITLE
Another typo slain

### DIFF
--- a/Chapter2_MorePyMC/MorePyMC.ipynb
+++ b/Chapter2_MorePyMC/MorePyMC.ipynb
@@ -8,7 +8,7 @@
   {
    "cells": [
     {
-     "cell_type": "markdown",wi
+     "cell_type": "markdown",
      "metadata": {},
      "source": [
       "Chapter 2\n",


### PR DESCRIPTION
an uniform prior --> a uniform prior.

I should put all these in one PR...
