### PR TITLE
separation_plot.py (Chapter2): fix plot off-by-one problem

### DIFF
--- a/Chapter2_MorePyMC/separation_plot.py
+++ b/Chapter2_MorePyMC/separation_plot.py
@@ -36,16 +36,17 @@ def separation_plot( p, y, **kwargs ):
         ax = fig.add_subplot(M, 1, i+1)
         ix = np.argsort( p[:,i] )
         #plot the different bars
-        bars = ax.bar( np.arange(n), np.ones(n), width=1., 
+        bars = ax.bar( np.arange(n), np.ones(n), width=1.,
+                align = 'center',
                 color = colors_bmh[ y[ix].astype(int) ], 
                 edgecolor = 'none')
-        ax.plot( np.arange(n), p[ix,i], "k", 
-                linewidth = 1.,drawstyle="steps-post" )
+        ax.plot( np.arange(n+1)-0.5, np.append(p[ix,i], p[ix,i][-1]), "k",
+                 linewidth = 1.,drawstyle="steps-post" )
         #create expected value bar.
         ax.vlines( [(1-p[ix,i]).sum()], [0], [1] )
         #ax.grid(False)
         #ax.axis('off')
-        plt.xlim( 0, n-1)
+        plt.xlim( -0.5, n-1+0.5)
         
     plt.tight_layout()
     


### PR DESCRIPTION
The last data point of the plot was missing, because it was plotted
beyond the xlim(). And drawstyle="steps-post" only draws a short
vertical line for the last point; add a final point to fix this.

And center the bars on the x-axis on integer samples.
