### PR TITLE
separation_plot.py: fix expected value bar

### DIFF
--- a/Chapter2_MorePyMC/separation_plot.py
+++ b/Chapter2_MorePyMC/separation_plot.py
@@ -37,16 +37,15 @@ def separation_plot( p, y, **kwargs ):
         ix = np.argsort( p[:,i] )
         #plot the different bars
         bars = ax.bar( np.arange(n), np.ones(n), width=1.,
-                align = 'center',
                 color = colors_bmh[ y[ix].astype(int) ], 
                 edgecolor = 'none')
-        ax.plot( np.arange(n+1)-0.5, np.append(p[ix,i], p[ix,i][-1]), "k",
+        ax.plot( np.arange(n+1), np.append(p[ix,i], p[ix,i][-1]), "k",
                  linewidth = 1.,drawstyle="steps-post" )
         #create expected value bar.
         ax.vlines( [(1-p[ix,i]).sum()], [0], [1] )
         #ax.grid(False)
         #ax.axis('off')
-        plt.xlim( -0.5, n-1+0.5)
+        plt.xlim( 0, n)
         
     plt.tight_layout()
     


### PR DESCRIPTION
The expected value bar is incompatible with the bar-centering from
in my previous commit. So, revert to left-aligned bars.
