### PR TITLE
Fixes the tau random variable thrice

### DIFF
--- a/Chapter1_Introduction/Chapter1_Introduction.ipynb
+++ b/Chapter1_Introduction/Chapter1_Introduction.ipynb
@@ -665,7 +665,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "print \"Random output:\", tau.random(), tau.random(), tau.random()"
+      "print \"Random output:\", lambda_1.random(), lambda_2.random(), tau.random()"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
The example of a PyMC stochastic variable was using `tau` three times and not the two lambda variables at all. This makes it clearer that they are all PyMC stochastic variables.