### PR TITLE
Fix minor typo to show possession.

### DIFF
--- a/Chapter2_MorePyMC/Chapter2.ipynb
+++ b/Chapter2_MorePyMC/Chapter2.ipynb
@@ -59,7 +59,7 @@
       "\n",
       "Likewise, `data_generator` is a parent to the variable `data_plus_one` (hence making `data_generator` both a parent and child variable). Although it does not look like one, `data_plus_one` should be treated as a PyMC variable as it is a *function* of another PyMC variable, hence is a child variable to `data_generator`.\n",
       "\n",
-      "This nomenclature is introduced to help us describe relationships in PyMC modeling. You can access a variables children and parent variables using the `children` and `parents` attributes attached to variables."
+      "This nomenclature is introduced to help us describe relationships in PyMC modeling. You can access a variable's children and parent variables using the `children` and `parents` attributes attached to variables."
      ]
     },
     {


### PR DESCRIPTION
"You can access a variables children and parent variables..." 
=> 
"You can access a variable's children and parent variables..."
