### PR TITLE
Update to bmh_matplotlibrc.json

### DIFF
--- a/styles/bmh_matplotlibrc.json
+++ b/styles/bmh_matplotlibrc.json
@@ -1,6 +1,5 @@
 {
   "lines.linewidth": 2.0,
-  "examples.download": true,
   "axes.edgecolor": "#bcbcbc",
   "patch.linewidth": 0.5,
   "legend.fancybox": true,
@@ -18,6 +17,6 @@
   "axes.grid": true,
   "patch.edgecolor": "#eeeeee",
   "axes.titlesize": "x-large",
-  "svg.embed_char_paths": "path",
+  "svg.fonttype": "path",
   "examples.directory": ""
 }


### PR DESCRIPTION
Running this code on ipython notebook 3.1 with matplotlib 1.4.3 on python 3.4.1 on windows, I was generating errors:

svg.embedded_char_paths is depreciated and replaced with svg.fonttype

and

examples.download is not a valid rc parameter