### PR TITLE
Update Prologue.ipynb broken link

### DIFF
--- a/Prologue/Prologue.ipynb
+++ b/Prologue/Prologue.ipynb
@@ -117,7 +117,7 @@
       "    -  For Linux users, you should not have a problem installing Numpy, Scipy, Matplotlib and PyMC. For Windows users, check out [pre-compiled versions](http://www.lfd.uci.edu/~gohlke/pythonlibs/) if you have difficulty. \n",
       "    -  In the styles/ directory are a number of files (.matplotlirc) that used to make things pretty. These are not only designed for the book, but they offer many improvements over the default settings of matplotlib and the IPython notebook.\n",
       "    -  while technically not required, it may help to run the IPython notebook with `--pylab inline` if you encounter runtime errors.\n",
-      "2. The second, preferred, option is to use the nbviewer.ipython.org site, which display IPython notebooks in the browser ([example](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter1_Introduction/Chapter1_Introduction.ipynb)).\n",
+      "2. The second, preferred, option is to use the nbviewer.ipython.org site, which display IPython notebooks in the browser ([example](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter1_Introduction/Chapter1.ipynb)).\n",
       "The contents are updated synchronously as commits are made to the book. You can use the Contents section above to link to the chapters.\n",
       " \n",
       "3. **PDF versions are coming.** PDFs are the least-preferred method to read the book, as pdf's are static and non-interactive. If PDFs are desired, they can be created dynamically using Chrome's builtin print-to-pdf feature.\n",


### PR DESCRIPTION
The hyperlink example under option 2 (reading on nbviewer.ipython.org) on ways to read the book was broken. Fixed.