### PR TITLE
Fixing matplotlib subplot deprecation warning/error

### DIFF
--- a/Chapter2_MorePyMC/Chapter2.ipynb
+++ b/Chapter2_MorePyMC/Chapter2.ipynb
@@ -626,7 +626,7 @@
       "\n",
       "figsize(12.5, 5)\n",
       "plt.title(\"More example of artificial datasets\")\n",
-      "for i in range(4):\n",
+      "for i in range(1, 5):\n",
       "    plt.subplot(4, 1, i)\n",
       "    plot_artificial_sms_dataset()"
      ],

--- a/Chapter3_MCMC/Chapter3.ipynb
+++ b/Chapter3_MCMC/Chapter3.ipynb
@@ -667,7 +667,7 @@
       "figsize(11.0, 4)\n",
       "std_trace = mcmc.trace(\"stds\")[:]\n",
       "\n",
-      "_i = [1, 2, 3, 0]\n",
+      "_i = [1, 2, 3, 4]\n",
       "for i in range(2):\n",
       "    plt.subplot(2, 2, _i[2 * i])\n",
       "    plt.title(\"Posterior of center of cluster %d\" % i)\n",


### PR DESCRIPTION
Fixing matplotlib subplot deprecation warning/error where a zero cannot be passed as argument.

I have matplotlib version 1.4.2. When the final argument of subplot is zero, this is printed when in std error having pasted the code to a .py file:
    /usr/lib/python2.7/dist-packages/matplotlib/axes/_subplots.py:69: MatplotlibDeprecationWarning: The use of 0 (which ends up being the _last_ sub-plot) is deprecated in 1.4 and will raise an error in 1.5

Examples demonstrating issue - comment in/out the lines to show the behaviour:
    Ch2: https://gist.github.com/noelevans/a95b1c2bb2088f26b545
    Ch3: https://gist.github.com/noelevans/0a1439da4ae200ffe05a

There doesn't seem to be a problem when subplot is used like this: 
    plt.subplot(410)
just this causes a problem:
    plt.subplot(4, 1, 0)