### PR TITLE
Fix index to list when there is no 2nd element

### DIFF
--- a/Chapter4_TheGreatestTheoremNeverTold/top_pic_comments.py
+++ b/Chapter4_TheGreatestTheoremNeverTold/top_pic_comments.py
@@ -12,7 +12,7 @@ subreddit  = reddit.get_subreddit( "pics" )
 top_submissions = subreddit.get_top()
 
 
-n_pic = int( sys.argv[1] ) if sys.argv[1] else 1
+n_pic = int( sys.argv[1] ) if len(sys.argv) > 1 else 1
 
 i = 0
 while i < n_pic:
@@ -39,25 +39,25 @@ for comment in _all_comments:
                 contents.append( comment.body )
             except Exception as e:
                 continue
-                
+
 votes = np.array( [ upvotes, downvotes] ).T
 
 
 
 
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 


### PR DESCRIPTION
When the module is run like this:
    python top_pic_comments.py
the variable sys.argv is:
    ['top_pic_comments.py']
So only a 0th element is available, not a 1st. Simple fix to check the length of argv

Testing below:

##########
# Before fix

# With numerical arg after module name
> python top_pic_comments.py 1
Title of submission: 
After floods in England, swans in the street - Worcester
http://i.imgur.com/IeIaWzK.jpg

# Without numerical arg - error thrown
> python top_pic_comments.py 
Traceback (most recent call last):
  File "top_pic_comments.py", line 15, in <module>
    n_pic = int( sys.argv[1] ) if sys.argv[1] else 1
IndexError: list index out of range

##########
# Made fix

# With numerical arg after module name
> python top_pic_comments.py 1
Title of submission: 
After floods in England, swans in the street - Worcester
http://i.imgur.com/IeIaWzK.jpg

# Without numerical arg
> python top_pic_comments.py 
Title of submission: 
After floods in England, swans in the street - Worcester
http://i.imgur.com/IeIaWzK.jpg
