### PR TITLE
Removed unused alias

### DIFF
--- a/Chapter6_Priorities/Chapter6.ipynb
+++ b/Chapter6_Priorities/Chapter6.ipynb
@@ -386,8 +386,6 @@
    "source": [
     "from pymc import rbeta\n",
     "\n",
-    "rand = np.random.rand\n",
-    "\n",
     "\n",
     "class Bandits(object):\n",
     "\n",


### PR DESCRIPTION
The var `rand` isn't used in the chapter so this line can be removed:
`rand = np.random.rand`

Sorry for sending a stale version before - I'm still quite new to Git.