### PR TITLE
make the pdf building script use --to pdf and build a single file

### DIFF
--- a/to_latex_pdf.sh
+++ b/to_latex_pdf.sh
@@ -1,6 +1,0 @@
-cd Chapter1_Introduction/ && ipython nbconvert Chapter1.ipynb --to latex --post PDF  --template article
-cd ../Chapter2_MorePyMC/ && ipython nbconvert Chapter2.ipynb --to latex --post PDF --template article
-cd ../Chapter3_MCMC/ && ipython nbconvert Chapter3.ipynb --to latex --post PDF --template article
-cd ../Chapter4_TheGreatestTheoremNeverTold/ && ipython nbconvert Chapter4.ipynb --to latex --post PDF --template article
-cd ../Chapter5_LossFunctions/ && ipython nbconvert Chapter5.ipynb --to latex --post PDF --template article
-cd ../Chapter6_Priorities/ && ipython nbconvert Chapter6.ipynb --to latex --post PDF --template article

--- a/to_pdf.sh
+++ b/to_pdf.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# builds a pdf version of the book, requires a latex distribution and pdf toolkit
+
+# get an ordered array of dirs ("prologue can be added in before the chapters once it's possible to build it")
+dirs="$(ls -d Chapter*)"
+dirs=(${dirs//\\n/})
+
+# get an array of notebook files based on the ordered dirs array
+notes=()
+for i in "${dirs[@]}"
+    do notes=("${notes[@]}" $(find "$i" -regex '.*\.ipynb'))
+done
+
+# build the notebook files
+for i in "${notes[@]}"
+    do ipython nbconvert $i --to pdf
+done
+
+# make a list of the pdfs
+pdfs=()
+for i in ${notes[@]}
+    do pdfs=( ${pdfs[@]} $(echo "$i" | sed 's/.*\///; s/ipynb/pdf/') )
+done
+
+# concatenate everything into a single pdf
+pdftk ${pdfs[@]} cat output book.pdf
+
+# remove intermediates
+rm -f ${pdfs[@]}


### PR DESCRIPTION
This pull request fixes the deprecated use of --to latex --post PDF. I also took the liberty to make it build a single file.