### PR TITLE
Fixing PDF creation problems caused by ipython 3.0 upgrade ipython/ipython#7973

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ipython>=0.13.2
+ipython>=3.0.0
 matplotlib>=1.2.1
 numpy>=1.7.1
 pymc==2.3.4

--- a/to_latex_pdf.sh
+++ b/to_latex_pdf.sh
@@ -1,6 +1,6 @@
-cd Chapter1_Introduction/ && ipython nbconvert Chapter1.ipynb --to latex --post PDF  --template article
-cd ../Chapter2_MorePyMC/ && ipython nbconvert Chapter2.ipynb --to latex --post PDF --template article
-cd ../Chapter3_MCMC/ && ipython nbconvert Chapter3.ipynb --to latex --post PDF --template article
-cd ../Chapter4_TheGreatestTheoremNeverTold/ && ipython nbconvert Chapter4.ipynb --to latex --post PDF --template article
-cd ../Chapter5_LossFunctions/ && ipython nbconvert Chapter5.ipynb --to latex --post PDF --template article
-cd ../Chapter6_Priorities/ && ipython nbconvert Chapter6.ipynb --to latex --post PDF --template article
+cd Chapter1_Introduction/ && ipython nbconvert Chapter1.ipynb --to pdf  --template article
+cd ../Chapter2_MorePyMC/ && ipython nbconvert Chapter2.ipynb --to pdf --template article
+cd ../Chapter3_MCMC/ && ipython nbconvert Chapter3.ipynb --to pdf --template article
+cd ../Chapter4_TheGreatestTheoremNeverTold/ && ipython nbconvert Chapter4.ipynb --to pdf --template article
+cd ../Chapter5_LossFunctions/ && ipython nbconvert Chapter5.ipynb --to pdf --template article
+cd ../Chapter6_Priorities/ && ipython nbconvert Chapter6.ipynb --to pdf --template article


### PR DESCRIPTION
The current script version produces an error if run with a recent ipython>=3.0.0 due to a change in ipython:
```
ImportError: No module named PDF
```
Please see ipython/ipython#7973

This pull request fixes PDF creation problems caused by ipython 3.0 upgrade.
