### PR TITLE
Fix nbviewer read-online links

### DIFF
--- a/Chapter1_Introduction/README.md
+++ b/Chapter1_Introduction/README.md
@@ -1,4 +1,4 @@
 Chapter 1: Introduction to Bayesian Methods
 ===========
 
-### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter1_Introduction/Chapter1.ipynb)
+### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter1_Introduction/Ch1_Introduction_PyMC2.ipynb)

--- a/Chapter2_MorePyMC/README.md
+++ b/Chapter2_MorePyMC/README.md
@@ -1,4 +1,4 @@
 Chapter 2: A little more on PyMC
 =================================
 
-### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter2_MorePyMC/Chapter2.ipynb)
+### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter2_MorePyMC/Chapter2_PyMC2.ipynb)

--- a/Chapter2_MorePyMC/README.md
+++ b/Chapter2_MorePyMC/README.md
@@ -1,4 +1,4 @@
 Chapter 2: A little more on PyMC
 =================================
 
-### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter2_MorePyMC/Chapter2_PyMC2.ipynb)
+### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter2_MorePyMC/Ch2_MorePyMC_PyMC2.ipynb)

--- a/Chapter3_MCMC/README.md
+++ b/Chapter3_MCMC/README.md
@@ -1,4 +1,4 @@
 Chapter 3: Opening the black box of MCMC (Markov Chain Monte Carlo)
 ==================================================================
 
-### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter3_MCMC/Chapter3.ipynb)
+### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter3_MCMC/Chapter3_PyMC2.ipynb)

--- a/Chapter3_MCMC/README.md
+++ b/Chapter3_MCMC/README.md
@@ -1,4 +1,4 @@
 Chapter 3: Opening the black box of MCMC (Markov Chain Monte Carlo)
 ==================================================================
 
-### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter3_MCMC/Chapter3_PyMC2.ipynb)
+### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter3_MCMC/Ch3_IntroMCMC_PyMC2.ipynb)

--- a/Chapter4_TheGreatestTheoremNeverTold/README.md
+++ b/Chapter4_TheGreatestTheoremNeverTold/README.md
@@ -1,3 +1,3 @@
 Chapter 4: The Greatest Theorem Never Told
 ====
-### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter4_TheGreatestTheoremNeverTold/Chapter4_PyMC2.ipynb)
+### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_PyMC2.ipynb)

--- a/Chapter4_TheGreatestTheoremNeverTold/README.md
+++ b/Chapter4_TheGreatestTheoremNeverTold/README.md
@@ -1,3 +1,3 @@
 Chapter 4: The Greatest Theorem Never Told
 ====
-### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter4_TheGreatestTheoremNeverTold/Chapter4.ipynb)
+### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter4_TheGreatestTheoremNeverTold/Chapter4_PyMC2.ipynb)

--- a/Chapter5_LossFunctions/README.md
+++ b/Chapter5_LossFunctions/README.md
@@ -1,4 +1,4 @@
 Chapter 5: Would you rather lose an arm or a leg?
 ====
 
-### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter5_LossFunctions/Chapter5.ipynb)
+### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter5_LossFunctions/Chapter5_PyMC2.ipynb)

--- a/Chapter5_LossFunctions/README.md
+++ b/Chapter5_LossFunctions/README.md
@@ -1,4 +1,4 @@
 Chapter 5: Would you rather lose an arm or a leg?
 ====
 
-### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter5_LossFunctions/Chapter5_PyMC2.ipynb)
+### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter5_LossFunctions/Ch5_LossFunctions_PyMC2.ipynb)

--- a/Chapter6_Priorities/README.md
+++ b/Chapter6_Priorities/README.md
@@ -1,4 +1,4 @@
 Chapter 6: Getting our priorities straight
 ===========
 
-### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter6_Priorities/Chapter6.ipynb)
+### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter6_Priorities/Chapter6_PyMC2.ipynb)

--- a/Chapter6_Priorities/README.md
+++ b/Chapter6_Priorities/README.md
@@ -1,4 +1,4 @@
 Chapter 6: Getting our priorities straight
 ===========
 
-### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter6_Priorities/Chapter6_PyMC2.ipynb)
+### [Read it online here](http://nbviewer.ipython.org/urls/raw.github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter6_Priorities/Ch6_Priors_PyMC2.ipynb)


### PR DESCRIPTION
These got broken when the PyMC3 versions came out.