### PR TITLE
Use theano.tensor.switch instead of pm.switch

### DIFF
--- a/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb
+++ b/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb
@@ -678,7 +678,7 @@
    "source": [
     "with model:\n",
     "    idx = np.arange(n_count_data) # Index\n",
-    "    lambda_ = tt.switch(tau >= idx, lambda_1, lambda_2)"
+    "    lambda_ = pm.math.switch(tau >= idx, lambda_1, lambda_2)"
    ]
   },
   {

--- a/Chapter2_MorePyMC/Ch2_MorePyMC_PyMC3.ipynb
+++ b/Chapter2_MorePyMC/Ch2_MorePyMC_PyMC3.ipynb
@@ -330,10 +330,11 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "\n",
     "n_data_points = 5  # in CH1 we had ~70 data points\n",
     "idx = np.arange(n_data_points)\n",
     "with model:\n",
-    "    lambda_ = pm.switch(tau >= idx, lambda_1, lambda_2)"
+    "    lambda_ = pm.math.switch(tau >= idx, lambda_1, lambda_2)"
    ]
   },
   {
@@ -384,7 +385,6 @@
     }
    ],
    "source": [
-    "import numpy as np\n",
     "import theano.tensor as tt\n",
     "\n",
     "with pm.Model() as theano_test:\n",
@@ -2646,21 +2646,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
pm.switch does not exist and is replaced by theano.tensor.switch (same as pm.math.switch) in PyMC3.

Chapter 1 already uses theano's switch.