### PR TITLE
Add missing import of scipy.stats

### DIFF
--- a/Chapter6_Priorities/Ch6_Priors_PyMC3.ipynb
+++ b/Chapter6_Priorities/Ch6_Priors_PyMC3.ipynb
@@ -58,6 +58,7 @@
    "source": [
     "%matplotlib inline\n",
     "import numpy as np\n",
+    "import scipy.stats as stats\n",
     "from IPython.core.pylabtools import figsize\n",
     "import matplotlib.pyplot as plt\n",
     "\n",


### PR DESCRIPTION
scipy.stats is not imported for the PyMC3 version of the chapter.