### PR TITLE
Fix #277 Ch6 portfolio optimization equation

### DIFF
--- a/Chapter6_Priorities/Ch6_Priors_PyMC2.ipynb
+++ b/Chapter6_Priorities/Ch6_Priors_PyMC2.ipynb
@@ -1378,7 +1378,7 @@
     "\n",
     "With this Bayesian analysis of the stock market, we can throw it into a Mean-Variance optimizer (which I cannot stress enough to not use with frequentist point estimates) and find the minimum. This optimizer balances the tradeoff between a high return and high variance.\n",
     "\n",
-    "$$ w_{opt} = \\min_{w} \\frac{1}{N}\\left( \\sum_{i=0}^N \\mu_i^T w - \\frac{\\lambda}{2}w^T\\Sigma_i w \\right)$$\n",
+    "$$ w_{opt} = \\max_{w} \\frac{1}{N}\\left( \\sum_{i=0}^N \\mu_i^T w - \\frac{\\lambda}{2}w^T\\Sigma_i w \\right)$$\n",
     "\n",
     "where $\\mu_i$ and $\\Sigma_i$ are the $i$th posterior estimate of the mean returns and the covariance matrix. This is another example of loss function optimization."
    ]

--- a/Chapter6_Priorities/Ch6_Priors_PyMC3.ipynb
+++ b/Chapter6_Priorities/Ch6_Priors_PyMC3.ipynb
@@ -1378,7 +1378,7 @@
     "\n",
     "With this Bayesian analysis of the stock market, we can throw it into a Mean-Variance optimizer (which I cannot stress enough, do not use with frequentist point estimates) and find the minimum. This optimizer balances the tradeoff between a high return and high variance.\n",
     "\n",
-    "$$ w_{opt} = \\min_{w} \\frac{1}{N}\\left( \\sum_{i=0}^N \\mu_i^T w - \\frac{\\lambda}{2}w^T\\Sigma_i w \\right)$$\n",
+    "$$ w_{opt} = \\max_{w} \\frac{1}{N}\\left( \\sum_{i=0}^N \\mu_i^T w - \\frac{\\lambda}{2}w^T\\Sigma_i w \\right)$$\n",
     "\n",
     "where $\\mu_i$ and $\\Sigma_i$ are the $i$th posterior estimate of the mean returns and the covariance matrix. This is another example of loss function optimization."
    ]


### PR DESCRIPTION
Substitute "max" for "min".

If lambda = 1, then the objective function approximates the portfolio's
geometric mean return, and that's something one should maximize
with respect to the weights (which by construction should sum to 1).

Fix approved by owner:
modified:   Ch6_Priors_PyMC2.ipynb
modified:   Ch6_Priors_PyMC3.ipynb
and these notebooks need to be in trusted state later.