### PR TITLE
Fix off by one error in Chapter 1 PyMC3, #338

### DIFF
--- a/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb
+++ b/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb
@@ -678,7 +678,7 @@
    "source": [
     "with model:\n",
     "    idx = np.arange(n_count_data) # Index\n",
-    "    lambda_ = pm.math.switch(tau >= idx, lambda_1, lambda_2)"
+    "    lambda_ = pm.math.switch(tau > idx, lambda_1, lambda_2)"
    ]
   },
   {


### PR DESCRIPTION
#338 mentioned two problems: one with prior for `tau` (seems to be fixed by @taylorterry3 already) and an off-by-one in the `lambda_` definition. This is the one-liner change to fix the second problem.