### PR TITLE
fix dead link to the project's "homepage"

### DIFF
--- a/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb
+++ b/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb
@@ -17,7 +17,7 @@
     "___\n",
     "\n",
     "\n",
-    "Welcome to *Bayesian Methods for Hackers*. The full Github repository is available at [github/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers](https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers). The other chapters can be found on the project's [homepage](g). We hope you enjoy the book, and we encourage any contributions!"
+    "Welcome to *Bayesian Methods for Hackers*. The full Github repository is available at [github/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers](https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers). The other chapters can be found on the project's [homepage](https://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/). We hope you enjoy the book, and we encourage any contributions!"
    ]
   },
   {


### PR DESCRIPTION
Getting to the notebook via the main page at https://nbviewer.jupyter.org/ shows the notebook with a 'homepage' link, clicking on it gives a 404 error.