### PR TITLE
Badge to run this repository on Azure Notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # [Bayesian Methods for Hackers](http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/)
+
+[![Azure Notebooks](https://notebooks.azure.com/launch.png)](https://notebooks.azure.com/import/gh/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers)
+
+
 #### *Using Python and PyMC*
 
 


### PR DESCRIPTION
I work at Microsoft on Azure Notebooks; a service that hosts Jupyter. This PR adds a badge that will make it easy to run the code in Azure Notebooks.

You can also create an account on Azure Notebooks and clone this repository yourself. And instead of accepting my PR, you can add a badge that points to your library. The benefit of this is it will allow you to see who is using Azure Notebooks, see the clones of the notebooks, and compare the changes to see what users are doing with your library. Once you have created your clone, the badge is under the 'share' button.