### PR TITLE
Don't attempt to install wsgiref under Python 3.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ pymc==2.3.4
 pyzmq>=13.1.0
 scipy>=0.12.0
 tornado>=3.0.2
-wsgiref>=0.1.2
+wsgiref>=0.1.2; python_version < '3.0'
 praw>=2.0.0
 jinja2


### PR DESCRIPTION
The wsgiref install fails in Python 3.6 due to a syntax error, but the
library appears to already be available as part of the standard library.

This change adds a pip directive to only install wsgiref under Python 2.