### PR TITLE
Spelling/grammar fixes for ch 2, 4, 5, 6

### DIFF
--- a/Chapter2_MorePyMC/Ch2_MorePyMC_PyMC3.ipynb
+++ b/Chapter2_MorePyMC/Ch2_MorePyMC_PyMC3.ipynb
@@ -739,7 +739,7 @@
     "\n",
     "With respect to our A/B example, we are interested in using what we know, $N$ (the total trials administered) and $n$ (the number of conversions), to estimate what $p_A$, the true frequency of buyers, might be. \n",
     "\n",
-    "To setup a Bayesian model, we need to assign prior distrbutions to our unknown quantities. *A priori*, what do we think $p_A$ might be? For this example, we have no strong conviction about $p_A$, so for now, let's assume $p_A$ is uniform over [0,1]:"
+    "To setup a Bayesian model, we need to assign prior distributions to our unknown quantities. *A priori*, what do we think $p_A$ might be? For this example, we have no strong conviction about $p_A$, so for now, let's assume $p_A$ is uniform over [0,1]:"
    ]
   },
   {

--- a/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_PyMC2.ipynb
+++ b/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_PyMC2.ipynb
@@ -507,7 +507,7 @@
     }
    ],
    "source": [
-    "# adding a number to the end of the %run call with get the ith top photo.\n",
+    "# adding a number to the end of the %run call will get the ith top post.\n",
     "%run top_showerthoughts_submissions.py 2\n",
     "\n",
     "print(\"Post contents: \\n\")\n",

--- a/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_PyMC3.ipynb
+++ b/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_PyMC3.ipynb
@@ -69,7 +69,7 @@
     "\n",
     "Below is a diagram of the Law of Large numbers in action for three different sequences of Poisson random variables. \n",
     "\n",
-    " We sample `sample_size = 100000` Poisson random variables with parameter $\\lambda = 4.5$. (Recall the expected value of a Poisson random variable is equal to it's parameter.) We calculate the average for the first $n$ samples, for $n=1$ to `sample_size`. "
+    " We sample `sample_size = 100000` Poisson random variables with parameter $\\lambda = 4.5$. (Recall the expected value of a Poisson random variable is equal to its parameter.) We calculate the average for the first $n$ samples, for $n=1$ to `sample_size`. "
    ]
   },
   {
@@ -354,7 +354,7 @@
    "source": [
     "What do we observe? *Without accounting for population sizes* we run the risk of making an enormous inference error: if we ignored population size, we would say that the county with the shortest and tallest individuals have been correctly circled. But this inference is wrong for the following reason. These two counties do *not* necessarily have the most extreme heights. The error results from the calculated average of smaller populations not being a good reflection of the true expected value of the population (which in truth should be $\\mu =150$). The sample size/population size/$N$, whatever you wish to call it,  is simply too small to invoke the Law of Large Numbers effectively. \n",
     "\n",
-    "We provide more damning evidence against this inference. Recall the population numbers were uniformly distributed over 100 to 1500. Our intuition should tell us that the counties with the most extreme population heights should also be uniformly spread over 100 to 4000, and certainly independent of the county's population. Not so. Below are the population sizes of the counties with the most extreme heights."
+    "We provide more damning evidence against this inference. Recall the population numbers were uniformly distributed over 100 to 1500. Our intuition should tell us that the counties with the most extreme population heights should also be uniformly spread over 100 to 1500, and certainly independent of the county's population. Not so. Below are the population sizes of the counties with the most extreme heights."
    ]
   },
   {
@@ -508,7 +508,7 @@
     }
    ],
    "source": [
-    "#adding a number to the end of the %run call with get the ith top post.\n",
+    "#adding a number to the end of the %run call will get the ith top post.\n",
     "%run top_showerthoughts_submissions.py 2\n",
     "\n",
     "print(\"Post contents: \\n\")\n",

--- a/Chapter5_LossFunctions/Ch5_LossFunctions_PyMC2.ipynb
+++ b/Chapter5_LossFunctions/Ch5_LossFunctions_PyMC2.ipynb
@@ -64,7 +64,7 @@
     "\n",
     "\n",
     "- $L( \\theta, \\hat{\\theta} ) = \\frac{ | \\theta - \\hat{\\theta} | }{ \\theta(1-\\theta) }, \\; \\; \\hat{\\theta}, \\theta \\in [0,1]$ emphasizes an estimate closer to 0 or 1 since if the true value $\\theta$ is near 0 or 1, the loss will be *very* large unless $\\hat{\\theta}$ is similarly close to 0 or 1. \n",
-    "This loss function might be used by a political pundit who's job requires him or her to give confident \"Yes/No\" answers. This loss reflects that if the true parameter is close to 1 (for example, if a political outcome is very likely to occur), he or she would want to strongly agree as to not look like a skeptic. \n",
+    "This loss function might be used by a political pundit whose job requires him or her to give confident \"Yes/No\" answers. This loss reflects that if the true parameter is close to 1 (for example, if a political outcome is very likely to occur), he or she would want to strongly agree as to not look like a skeptic. \n",
     "\n",
     "-  $L( \\theta, \\hat{\\theta} ) =  1 - \\exp \\left( -(\\theta -  \\hat{\\theta} )^2 \\right)$ is bounded between 0 and 1 and reflects that the user is indifferent to sufficiently-far-away estimates. It is similar to the zero-one loss above, but not quite as penalizing to estimates that are close to the true parameter. \n",
     "-  Complicated non-linear loss functions can programmed: \n",

--- a/Chapter5_LossFunctions/Ch5_LossFunctions_PyMC3.ipynb
+++ b/Chapter5_LossFunctions/Ch5_LossFunctions_PyMC3.ipynb
@@ -70,7 +70,7 @@
     "\n",
     "\n",
     "- $L( \\theta, \\hat{\\theta} ) = \\frac{ | \\theta - \\hat{\\theta} | }{ \\theta(1-\\theta) }, \\; \\; \\hat{\\theta}, \\theta \\in [0,1]$ emphasizes an estimate closer to 0 or 1 since if the true value $\\theta$ is near 0 or 1, the loss will be *very* large unless $\\hat{\\theta}$ is similarly close to 0 or 1. \n",
-    "This loss function might be used by a political pundit who's job requires him or her to give confident \"Yes/No\" answers. This loss reflects that if the true parameter is close to 1 (for example, if a political outcome is very likely to occur), he or she would want to strongly agree as to not look like a skeptic. \n",
+    "This loss function might be used by a political pundit whose job requires him or her to give confident \"Yes/No\" answers. This loss reflects that if the true parameter is close to 1 (for example, if a political outcome is very likely to occur), he or she would want to strongly agree as to not look like a skeptic. \n",
     "\n",
     "-  $L( \\theta, \\hat{\\theta} ) =  1 - \\exp \\left( -(\\theta -  \\hat{\\theta} )^2 \\right)$ is bounded between 0 and 1 and reflects that the user is indifferent to sufficiently-far-away estimates. It is similar to the zero-one loss above, but not quite as penalizing to estimates that are close to the true parameter. \n",
     "-  Complicated non-linear loss functions can programmed: \n",

--- a/Chapter6_Priorities/Ch6_Priors_PyMC3.ipynb
+++ b/Chapter6_Priorities/Ch6_Priors_PyMC3.ipynb
@@ -1273,7 +1273,7 @@
    "source": [
     "(Plots like these are what inspired the book's cover.)\n",
     "\n",
-    "What can we say about the results above? Clearly TSLA has been a strong performer, and our analysis suggests that it has an almost 1% daily return! Similarly, most of the distribution of AAPL is negative, suggesting that it's *true daily return* is negative.\n",
+    "What can we say about the results above? Clearly TSLA has been a strong performer, and our analysis suggests that it has an almost 1% daily return! Similarly, most of the distribution of AAPL is negative, suggesting that its *true daily return* is negative.\n",
     "\n",
     "\n",
     "You may not have immediately noticed, but these variables are a whole order of magnitude *less* than our priors on them. For example, to put these one the same scale as the above prior distributions:"


### PR DESCRIPTION
**Fixes:**
- Chapter 2 (PyMC3): typo in "prior distributions" in last paragraph of "A Simple Case"
- Chapter 4 (PyMC3): typo in Law of Large Numbers Example - "... is equal to _it's_ parameter." (it's --> its)
- Chapter 4 (PyMC3): “Our intuition should tell us that the counties with the most extreme population heights should also be uniformly spread over 100 to _4000_” (4000 --> 1500)
- Chapter 4 (PyMC2 and PyMC3): `#adding a number to the end of the %run call _with_ get the ith top photo` (with --> will, photo --> post)
- Chapter 5 (PyMC2 and PyMC3): "This loss function might be used by a political pundit _who's_ job requires him or her to give confident "Yes/No" answers.” (who’s —> whose)
- Chapter 6 (PyMC3): "... suggesting that _it's_ true daily return is negative ..." (it's --> its)

Thanks for the read!