### PR TITLE
change 'overestimate' to 'underestimate'

### DIFF
--- a/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_PyMC2.ipynb
+++ b/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_PyMC2.ipynb
@@ -699,7 +699,8 @@
    "source": [
     "The best submissions, according to our procedure, are the submissions that are *most-likely* to score a high percentage of upvotes. Visually those are the submissions with the 95% least plausible value close to 1.\n",
     "\n",
-    "Why is sorting based on this quantity a good idea? By ordering by the 95% least plausible value, we are being the most conservative with what we think is best. That is, even in the worst case scenario, when we have severely overestimated the upvote ratio, we can be sure the best comments are still on top. Under this ordering, we impose the following very natural properties:\n",
+    "
+Why is sorting based on this quantity a good idea? By ordering by the 95% least plausible value, we are being the most conservative with what we think is best.  When using the lower-bound of the 95% credible interval, we believe with high certainty that the "true upvote ratio" is at the very least equal to this value (or greater), thereby ensuring that the best submissions are still on top. Under this ordering, we impose the following very natural properties:\n",
     "\n",
     "1. given two submissions with the same observed upvote ratio, we will assign the submission with more votes as better (since we are more confident it has a higher ratio).\n",
     "2. given two submissions with the same number of votes, we still assign the submission with more upvotes as *better*.\n",

--- a/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_PyMC3.ipynb
+++ b/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_PyMC3.ipynb
@@ -712,7 +712,7 @@
    "source": [
     "The best submissions, according to our procedure, are the submissions that are *most-likely* to score a high percentage of upvotes. Visually those are the submissions with the 95% least plausible value close to 1.\n",
     "\n",
-    "Why is sorting based on this quantity a good idea? By ordering by the 95% least plausible value, we are being the most conservative with what we think is best. That is, even in the worst case scenario, when we have severely overestimated the upvote ratio, we can be sure the best submissions are still on top. Under this ordering, we impose the following very natural properties:\n",
+    "Why is sorting based on this quantity a good idea? By ordering by the 95% least plausible value, we are being the most conservative with what we think is best.  When using the lower-bound of the 95% credible interval, we believe with high certainty that the "true upvote ratio" is at the very least equal to this value (or greater), thereby ensuring that the best submissions are still on top. Under this ordering, we impose the following very natural properties:\n",
     "\n",
     "1. given two submissions with the same observed upvote ratio, we will assign the submission with more votes as better (since we are more confident it has a higher ratio).\n",
     "2. given two submissions with the same number of votes, we still assign the submission with more upvotes as *better*.\n",


### PR DESCRIPTION
# Context

In the part about sorting Reddit reviews by lower-bound of the credible interval, the book says the following:

_Why is sorting based on this quantity a good idea? By ordering by the 95% least plausible value, we are being the most conservative with what we think is best. That is, even in the worst case scenario, when we have severely **overestimated** the upvote ratio, we can be sure the best submissions are still on top. Under this ordering, we impose the following very natural properties_

Since we are taking the lower-bound of the CI, by definition, we are more likely **underestimating** the "true upvote ratio," so we should use 'underestimate' instead of 'overestimate'.