### PR TITLE
Change lambda value to float type for Exponential

### DIFF
--- a/Chapter2_MorePyMC/Ch2_MorePyMC_PyMC3.ipynb
+++ b/Chapter2_MorePyMC/Ch2_MorePyMC_PyMC3.ipynb
@@ -45,7 +45,7 @@
     "import pymc3 as pm\n",
     "\n",
     "with pm.Model() as model:\n",
-    "    parameter = pm.Exponential(\"poisson_param\", 1)\n",
+    "    parameter = pm.Exponential(\"poisson_param\", 1.0)\n",
     "    data_generator = pm.Poisson(\"data_generator\", parameter)"
    ]
   },
@@ -123,7 +123,7 @@
    ],
    "source": [
     "with pm.Model() as model:\n",
-    "    theta = pm.Exponential(\"theta\", 2)\n",
+    "    theta = pm.Exponential(\"theta\", 2.0)\n",
     "    data_generator = pm.Poisson(\"data_generator\", theta)"
    ]
   },
@@ -221,7 +221,7 @@
    ],
    "source": [
     "with pm.Model() as model:\n",
-    "    parameter = pm.Exponential(\"poisson_param\", 1, testval=0.5)\n",
+    "    parameter = pm.Exponential(\"poisson_param\", 1.0, testval=0.5)\n",
     "\n",
     "print(\"\\nparameter.tag.test_value =\", parameter.tag.test_value)"
    ]
@@ -296,8 +296,8 @@
    ],
    "source": [
     "with pm.Model() as model:\n",
-    "    lambda_1 = pm.Exponential(\"lambda_1\", 1)\n",
-    "    lambda_2 = pm.Exponential(\"lambda_2\", 1)\n",
+    "    lambda_1 = pm.Exponential(\"lambda_1\", 1.0)\n",
+    "    lambda_2 = pm.Exponential(\"lambda_2\", 1.0)\n",
     "    tau = pm.DiscreteUniform(\"tau\", lower=0, upper=10)\n",
     "\n",
     "new_deterministic_variable = lambda_1 + lambda_2"
@@ -1607,7 +1607,7 @@
     "x = np.ones(N, dtype=object)\n",
     "with pm.Model() as model:\n",
     "    for i in range(0, N):\n",
-    "        x[i] = pm.Exponential('x_%i' % i, (i+1)**2)"
+    "        x[i] = pm.Exponential('x_%i' % i, (i+1.0)**2)"
    ]
   },
   {


### PR DESCRIPTION
Initially, ' Integers to negative integer powers are not allowed.' error would appear when I run the Exponential model. I read the doc file, and it says lam accepts float type only. 

I am not sure whether it is the python version issue or pymc3 version issue. Just want to point out the error and the way to fix it on my particular case.