### PR TITLE
removed an uneccessary for loop

### DIFF
--- a/Chapter2_MorePyMC/Ch2_MorePyMC_PyMC3.ipynb
+++ b/Chapter2_MorePyMC/Ch2_MorePyMC_PyMC3.ipynb
@@ -441,7 +441,7 @@
     "figsize(12.5, 4)\n",
     "\n",
     "\n",
-    "samples = [lambda_1.random()[0] for i in range(20000)]\n",
+    "samples = lambda_1.random(size=20000)\n",
     "plt.hist(samples, bins=70, normed=True, histtype=\"stepfilled\")\n",
     "plt.title(\"Prior distribution for $\\lambda_1$\")\n",
     "plt.xlim(0, 8);"


### PR DESCRIPTION
Instead of relying on an inline for loop for gathering a list of random samples from a distribution, one should use the size keyword accordingly.