### PR TITLE
Made Colab links automatically reflect Github repo contents

### DIFF
--- a/Chapter1_Introduction/Ch1_Introduction_TFP.ipynb
+++ b/Chapter1_Introduction/Ch1_Introduction_TFP.ipynb
@@ -32,7 +32,7 @@
         "    <a target=\"_blank\" href=\"https://drive.google.com/file/d/1r0JJuIQ9Uujpy8L941oMpJVrdQ6JLtSk/view?usp=sharing\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/blob/13ec2c5a49406d6986b6b5f2468d6fa0b8b5d5ac/Chapter1_Introduction/Ch1_Introduction_TFP.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/blob/master/Chapter1_Introduction/Ch1_Introduction_TFP.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
         "</table>\n",
         "<br>\n",

--- a/Chapter2_MorePyMC/Ch2_MorePyMC_TFP.ipynb
+++ b/Chapter2_MorePyMC/Ch2_MorePyMC_TFP.ipynb
@@ -30,7 +30,7 @@
         "    <a target=\"_blank\" href=\"https://drive.google.com/file/d/1HxnSpRwRMrQnXRrOhEtMLKe2ZN1SyrbJ/view?usp=sharing\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/blob/13ec2c5a49406d6986b6b5f2468d6fa0b8b5d5ac/Chapter2_MorePyMC/Ch2_MorePyMC_TFP.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/blob/master/Chapter2_MorePyMC/Ch2_MorePyMC_TFP.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
         "</table>\n",
         "<br>\n",

--- a/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_TFP.ipynb
+++ b/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_TFP.ipynb
@@ -29,7 +29,7 @@
         "    <a target=\"_blank\" href=\"https://drive.google.com/file/d/1xfwG-Mq9Nq-NjIxNtGXGKJ-GQozSHnDi/view?usp=sharing\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/blob/13ec2c5a49406d6986b6b5f2468d6fa0b8b5d5ac/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_TFP.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/blob/master/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_TFP.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
         "</table>\n",
         "<br>\n",


### PR DESCRIPTION
This update results in colab links that take whatever is at the specific
Github URL, and then provides a colab runtime environment for that
notebook. These notebooks cannot be saved over (thereby making them
runnable but not permenantly editable), but users can easily go into the
file bar and save their own runnable version of the notebook to Google
drive.