### PR TITLE
Ch2 TFP bug fix: use function argument rather than global variable

### DIFF
--- a/Chapter2_MorePyMC/Ch2_MorePyMC_TFP.ipynb
+++ b/Chapter2_MorePyMC/Ch2_MorePyMC_TFP.ipynb
@@ -1238,7 +1238,7 @@
     "  \n",
     "    return (\n",
     "        rv_prob_A.log_prob(prob_A)\n",
-    "        + tf.reduce_sum(rv_occurrences.log_prob(occurrences_))\n",
+    "        + tf.reduce_sum(rv_occurrences.log_prob(occurrences))\n",
     "    )"
    ]
   },


### PR DESCRIPTION
Fixes a typo in the joint log probability function that causes a global variable to be referenced rather than the intended function argument.