### PR TITLE
Fixed log-loss latex formula in Chapter 5

### DIFF
--- a/Chapter5_LossFunctions/Ch5_LossFunctions_PyMC2.ipynb
+++ b/Chapter5_LossFunctions/Ch5_LossFunctions_PyMC2.ipynb
@@ -54,7 +54,7 @@
     "Other popular loss functions include:\n",
     "\n",
     "-  $L( \\theta, \\hat{\\theta} ) = \\mathbb{1}_{ \\hat{\\theta} \\neq \\theta }$ is the zero-one loss often used in machine learning classification algorithms.\n",
-    "-  $L( \\theta, \\hat{\\theta} ) = -\\hat{\\theta}\\log( \\theta ) - (1-\\hat{ \\theta})\\log( 1 - \\theta ), \\; \\; \\hat{\\theta} \\in {0,1}, \\; \\theta \\in [0,1]$, called the *log-loss*, also used in machine learning. \n",
+    "-  $L( \\theta, \\hat{\\theta} ) = -\\theta\\log( \\hat{\\theta} ) - (1-\\theta)\\log( 1 - \\hat{\\theta} ), \\; \\; \\theta \\in {0,1}, \\; \\hat{\\theta} \\in [0,1]$, called the *log-loss*, also used in machine learning. \n",
     "\n",
     "Historically, loss functions have been motivated from 1) mathematical convenience, and 2) they are robust to application, i.e., they are objective measures of loss. The first reason has really held back the full breadth of loss functions. With computers being agnostic to mathematical convenience, we are free to design our own loss functions, which we take full advantage of later in this Chapter.\n",
     "\n",

--- a/Chapter5_LossFunctions/Ch5_LossFunctions_PyMC3.ipynb
+++ b/Chapter5_LossFunctions/Ch5_LossFunctions_PyMC3.ipynb
@@ -60,7 +60,7 @@
     "Other popular loss functions include:\n",
     "\n",
     "-  $L( \\theta, \\hat{\\theta} ) = \\mathbb{1}_{ \\hat{\\theta} \\neq \\theta }$ is the zero-one loss often used in machine learning classification algorithms.\n",
-    "-  $L( \\theta, \\hat{\\theta} ) = -\\hat{\\theta}\\log( \\theta ) - (1-\\hat{ \\theta})\\log( 1 - \\theta ), \\; \\; \\hat{\\theta} \\in {0,1}, \\; \\theta \\in [0,1]$, called the *log-loss*, also used in machine learning. \n",
+    "-  $L( \\theta, \\hat{\\theta} ) = -\\theta\\log( \\hat{\\theta} ) - (1- \\theta)\\log( 1 - \\hat{\\theta} ), \\; \\; \\theta \\in {0,1}, \\; \\hat{\\theta} \\in [0,1]$, called the *log-loss*, also used in machine learning. \n",
     "\n",
     "Historically, loss functions have been motivated from 1) mathematical convenience, and 2) they are robust to application, i.e., they are objective measures of loss. The first reason has really held back the full breadth of loss functions. With computers being agnostic to mathematical convenience, we are free to design our own loss functions, which we take full advantage of later in this Chapter.\n",
     "\n",

--- a/Chapter5_LossFunctions/Ch5_LossFunctions_TFP.ipynb
+++ b/Chapter5_LossFunctions/Ch5_LossFunctions_TFP.ipynb
@@ -280,7 +280,7 @@
     "Other popular loss functions include:\n",
     "\n",
     "-  $L( \\theta, \\hat{\\theta} ) = \\mathbb{1}_{ \\hat{\\theta} \\neq \\theta }$ is the zero-one loss often used in machine learning classification algorithms.\n",
-    "-  $L( \\theta, \\hat{\\theta} ) = -\\hat{\\theta}\\log( \\theta ) - (1-\\hat{ \\theta})\\log( 1 - \\theta ), \\; \\; \\hat{\\theta} \\in {0,1}, \\; \\theta \\in [0,1]$, called the *log-loss*, also used in machine learning. \n",
+    "-  $L( \\theta, \\hat{\\theta} ) = -\\theta\\log( \\hat{\\theta} ) - (1- \\theta)\\log( 1 - \\hat{\\theta} ), \\; \\; \\theta \\in {0,1}, \\; \\hat{\\theta} \\in [0,1]$, called the *log-loss*, also used in machine learning. \n",
     "\n",
     "Historically, loss functions have been motivated from 1) mathematical convenience, and 2) they are robust to application, i.e., they are objective measures of loss. The first reason has really held back the full breadth of loss functions. With computers being agnostic to mathematical convenience, we are free to design our own loss functions, which we take full advantage of later in this Chapter.\n",
     "\n",


### PR DESCRIPTION
I think the log-loss definition in Chapter 5 is wrong. 
The logarithm should be applied to the estimated probabilities.
I swapped around the `\\hat{}` to correct.