### PR TITLE
Fix small typo in initialisation of exp_y_

### DIFF
--- a/Chapter3_MCMC/Ch3_IntroMCMC_TFP.ipynb
+++ b/Chapter3_MCMC/Ch3_IntroMCMC_TFP.ipynb
@@ -383,7 +383,7 @@
    "source": [
     "exp_x_ = evaluate(tfd.Exponential(rate=(1./3.)).prob(x_))\n",
     "exp_x_[np.isnan(exp_x_)] = exp_x_[1]\n",
-    "exp_y_ = evaluate(tfd.Exponential(rate=(1./10.)).prob(x_))\n",
+    "exp_y_ = evaluate(tfd.Exponential(rate=(1./10.)).prob(y_))\n",
     "exp_y_[np.isnan(exp_y_)] = exp_y_[1]\n",
     "M_ = evaluate(tf.matmul(tf.expand_dims(exp_x_, 1), tf.expand_dims(exp_y_, 0)))\n",
     "\n",


### PR DESCRIPTION
A small cosmetic fix.  As `x_ == y_` it is not a material change of course.