### PR TITLE
Add seaborn and tensorflow to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ tornado>=3.0.2
 wsgiref>=0.1.2; python_version < '3.0'
 praw>=2.0.0
 jinja2
+seaborn
+tensorflow==1.13.1


### PR DESCRIPTION
Allows a user to successfully run the top setup cell of
Ch1_Introduction_TFP.

TensorFlow version is pinned to 1.13.1, the version running currently in
Colab.