### PR TITLE
Ch. 3 correction: MCMC *not* exploring the space well likely exhibits high autocorr.

### DIFF
--- a/Chapter3_MCMC/Ch3_IntroMCMC_PyMC2.ipynb
+++ b/Chapter3_MCMC/Ch3_IntroMCMC_PyMC2.ipynb
@@ -1091,7 +1091,7 @@
     "\n",
     "By the nature of the MCMC algorithm, we will always be returned samples that exhibit autocorrelation (this is because of the step `from your current position, move to a position near you`).\n",
     "\n",
-    "A chain that is [Isn't meandering exploring?] exploring the space well will exhibit very high autocorrelation. Visually, if the trace seems to meander like a river, and not settle down, the chain will have high autocorrelation.\n",
+    "A chain that is not exploring the space well will exhibit very high autocorrelation. Visually, if the trace seems to meander like a river, and not settle down, the chain will have high autocorrelation.\n",
     "\n",
     "This does not imply that a converged MCMC has low autocorrelation. Hence low autocorrelation is not necessary for convergence, but it is sufficient. PyMC has a built-in autocorrelation plotting function in the `Matplot` module. "
    ]

--- a/Chapter3_MCMC/Ch3_IntroMCMC_PyMC3.ipynb
+++ b/Chapter3_MCMC/Ch3_IntroMCMC_PyMC3.ipynb
@@ -1073,7 +1073,7 @@
     "\n",
     "By the nature of the MCMC algorithm, we will always be returned samples that exhibit autocorrelation (this is because of the step `from your current position, move to a position near you`).\n",
     "\n",
-    "A chain that is [Isn't meandering exploring?] exploring the space well will exhibit very high autocorrelation. Visually, if the trace seems to meander like a river, and not settle down, the chain will have high autocorrelation.\n",
+    "A chain that is not exploring the space well will exhibit very high autocorrelation. Visually, if the trace seems to meander like a river, and not settle down, the chain will have high autocorrelation.\n",
     "\n",
     "This does not imply that a converged MCMC has low autocorrelation. Hence low autocorrelation is not necessary for convergence, but it is sufficient. PyMC3 has a built-in autocorrelation plotting function in the `plots` module. "
    ]

--- a/Chapter3_MCMC/Ch3_IntroMCMC_TFP.ipynb
+++ b/Chapter3_MCMC/Ch3_IntroMCMC_TFP.ipynb
@@ -1909,7 +1909,7 @@
     "\n",
     "By the nature of the MCMC algorithm, we will always be returned samples that exhibit autocorrelation (this is because of the step `from your current position, move to a position near you`).\n",
     "\n",
-    "A chain that is [Isn't meandering exploring?] exploring the space well will exhibit very high autocorrelation. Visually, if the trace seems to meander like a river, and not settle down, the chain will have high autocorrelation.\n",
+    "A chain that is not exploring the space well will exhibit very high autocorrelation. Visually, if the trace seems to meander like a river, and not settle down, the chain will have high autocorrelation.\n",
     "\n",
     "This does not imply that a converged MCMC has low autocorrelation. Hence low autocorrelation is not necessary for convergence, but it is sufficient. TFP has a built-in autocorrelation tools as well. "
    ]


### PR DESCRIPTION
These sentences suggest that a chain exploring the space well will exhibit high autocorrelation. I think the intent was the convey the opposite, but I'm also new to this topic so please close this PR and enlighten me if this I'm wrong!