### PR TITLE
Chapter 4 indicator function - fix probability calculation

### DIFF
--- a/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_TFP.ipynb
+++ b/Chapter4_TheGreatestTheoremNeverTold/Ch4_LawOfLargeNumbers_TFP.ipynb
@@ -585,14 +585,14 @@
       "source": [
         "N = 10000\n",
         "\n",
-        "print(\"Probability Estimate: \", len(np.where(evaluate(tfd.Exponential(rate=0.5).sample(sample_shape=N)) > 5))/N )"
+        "print(\"Probability Estimate: \", np.shape(np.where(evaluate(tfd.Exponential(rate=0.5).sample(sample_shape=N)) > 5))[1]/N )"
       ],
       "execution_count": 4,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "Probability Estimate:  0.0001\n"
+            "Probability Estimate:  0.0823\n"
           ],
           "name": "stdout"
         }


### PR DESCRIPTION
Currently there is an error here because the `len` function returns `1` for any `N` - change `N` to see how the "Probability Estimate" changes as `1/N`.

Running my corrected version gives a much closer estimate of the true probability (~0.08208).

Also just to point out this TFP code is anyway different from the PyMC3 version because numpy use the scale rather than rate parameterisation of the exponential distribution. Thus the equivalent is shown below too.
```
N = 10000

print("Probability Estimate: ", len(np.where(evaluate(tfd.Exponential(rate=0.5).sample(sample_shape=N)) > 5))/N )

print("Corrected Probability Estimate: ", np.shape(np.where(evaluate(tfd.Exponential(rate=0.5).sample(sample_shape=N)) > 5))[1]/N )

print("From Pymc3 Probability Estimate: ",  np.mean( [ np.random.exponential(scale=2, size=N) > 5 ] ) )
```