### PR TITLE
[Typo fix] Replace tau with t

### DIFF
--- a/Chapter3_MCMC/Ch3_IntroMCMC_PyMC3.ipynb
+++ b/Chapter3_MCMC/Ch3_IntroMCMC_PyMC3.ipynb
@@ -968,7 +968,7 @@
     "\n",
     "### Autocorrelation\n",
     "\n",
-    "Autocorrelation is a measure of how related a series of numbers is with itself. A measurement of 1.0 is perfect positive autocorrelation, 0 no autocorrelation, and -1 is perfect negative correlation.  If you are familiar with standard *correlation*, then autocorrelation is just how correlated a series, $x_\\tau$, at time $t$ is with the series at time $t-k$:\n",
+    "Autocorrelation is a measure of how related a series of numbers is with itself. A measurement of 1.0 is perfect positive autocorrelation, 0 no autocorrelation, and -1 is perfect negative correlation.  If you are familiar with standard *correlation*, then autocorrelation is just how correlated a series, $x_t$, at time $t$ is with the series at time $t-k$:\n",
     "\n",
     "$$R(k) = Corr( x_t, x_{t-k} ) $$\n",
     "\n",


### PR DESCRIPTION
In the autocorrelation section of Chapter 3 for PyMC3, the series x is referred to as `x_tau` in one spot instead of `x_t`

![image](https://user-images.githubusercontent.com/11096727/78081933-c3214600-737f-11ea-9857-055947deccfe.png)
