### PR TITLE
'normed' property replaced with 'density' in plt.hist

### DIFF
--- a/Chapter2_MorePyMC/Ch2_MorePyMC_PyMC3.ipynb
+++ b/Chapter2_MorePyMC/Ch2_MorePyMC_PyMC3.ipynb
@@ -442,7 +442,7 @@
     "\n",
     "\n",
     "samples = lambda_1.random(size=20000)\n",
-    "plt.hist(samples, bins=70, normed=True, histtype=\"stepfilled\")\n",
+    "plt.hist(samples, bins=70, density=True, histtype=\"stepfilled\")\n",
     "plt.title(\"Prior distribution for $\\lambda_1$\")\n",
     "plt.xlim(0, 8);"
    ]
@@ -894,7 +894,7 @@
     "figsize(12.5, 4)\n",
     "plt.title(\"Posterior distribution of $p_A$, the true effectiveness of site A\")\n",
     "plt.vlines(p_true, 0, 90, linestyle=\"--\", label=\"true $p_A$ (unknown)\")\n",
-    "plt.hist(burned_trace[\"p\"], bins=25, histtype=\"stepfilled\", normed=True)\n",
+    "plt.hist(burned_trace[\"p\"], bins=25, histtype=\"stepfilled\", density=True)\n",
     "plt.legend();"
    ]
   },
@@ -1049,7 +1049,7 @@
     "\n",
     "plt.xlim(0, .1)\n",
     "plt.hist(p_A_samples, histtype='stepfilled', bins=25, alpha=0.85,\n",
-    "         label=\"posterior of $p_A$\", color=\"#A60628\", normed=True)\n",
+    "         label=\"posterior of $p_A$\", color=\"#A60628\", density=True)\n",
     "plt.vlines(true_p_A, 0, 80, linestyle=\"--\", label=\"true $p_A$ (unknown)\")\n",
     "plt.legend(loc=\"upper right\")\n",
     "plt.title(\"Posterior distributions of $p_A$, $p_B$, and delta unknowns\")\n",
@@ -1058,13 +1058,13 @@
     "\n",
     "plt.xlim(0, .1)\n",
     "plt.hist(p_B_samples, histtype='stepfilled', bins=25, alpha=0.85,\n",
-    "         label=\"posterior of $p_B$\", color=\"#467821\", normed=True)\n",
+    "         label=\"posterior of $p_B$\", color=\"#467821\", density=True)\n",
     "plt.vlines(true_p_B, 0, 80, linestyle=\"--\", label=\"true $p_B$ (unknown)\")\n",
     "plt.legend(loc=\"upper right\")\n",
     "\n",
     "ax = plt.subplot(313)\n",
     "plt.hist(delta_samples, histtype='stepfilled', bins=30, alpha=0.85,\n",
-    "         label=\"posterior of delta\", color=\"#7A68A6\", normed=True)\n",
+    "         label=\"posterior of delta\", color=\"#7A68A6\", density=True)\n",
     "plt.vlines(true_p_A - true_p_B, 0, 60, linestyle=\"--\",\n",
     "           label=\"true delta (unknown)\")\n",
     "plt.vlines(0, 0, 60, color=\"black\", alpha=0.2)\n",
@@ -1428,7 +1428,7 @@
    "source": [
     "figsize(12.5, 3)\n",
     "p_trace = burned_trace[\"freq_cheating\"][15000:]\n",
-    "plt.hist(p_trace, histtype=\"stepfilled\", normed=True, alpha=0.85, bins=30, \n",
+    "plt.hist(p_trace, histtype=\"stepfilled\", density=True, alpha=0.85, bins=30, \n",
     "         label=\"posterior distribution\", color=\"#348ABD\")\n",
     "plt.vlines([.05, .35], [0, 0], [5, 5], alpha=0.3)\n",
     "plt.xlim(0, 1)\n",
@@ -1559,7 +1559,7 @@
    "source": [
     "figsize(12.5, 3)\n",
     "p_trace = burned_trace[\"freq_cheating\"]\n",
-    "plt.hist(p_trace, histtype=\"stepfilled\", normed=True, alpha=0.85, bins=30, \n",
+    "plt.hist(p_trace, histtype=\"stepfilled\", density=True, alpha=0.85, bins=30, \n",
     "         label=\"posterior distribution\", color=\"#348ABD\")\n",
     "plt.vlines([.05, .35], [0, 0], [5, 5], alpha=0.2)\n",
     "plt.xlim(0, 1)\n",
@@ -1968,12 +1968,12 @@
     "plt.subplot(211)\n",
     "plt.title(r\"Posterior distributions of the variables $\\alpha, \\beta$\")\n",
     "plt.hist(beta_samples, histtype='stepfilled', bins=35, alpha=0.85,\n",
-    "         label=r\"posterior of $\\beta$\", color=\"#7A68A6\", normed=True)\n",
+    "         label=r\"posterior of $\\beta$\", color=\"#7A68A6\", density=True)\n",
     "plt.legend()\n",
     "\n",
     "plt.subplot(212)\n",
     "plt.hist(alpha_samples, histtype='stepfilled', bins=35, alpha=0.85,\n",
-    "         label=r\"posterior of $\\alpha$\", color=\"#A60628\", normed=True)\n",
+    "         label=r\"posterior of $\\alpha$\", color=\"#A60628\", density=True)\n",
     "plt.legend();"
    ]
   },
@@ -2132,7 +2132,7 @@
     "prob_31 = logistic(31, beta_samples, alpha_samples)\n",
     "\n",
     "plt.xlim(0.995, 1)\n",
-    "plt.hist(prob_31, bins=1000, normed=True, histtype='stepfilled')\n",
+    "plt.hist(prob_31, bins=1000, density=True, histtype='stepfilled')\n",
     "plt.title(\"Posterior distribution of probability of defect, given $t = 31$\")\n",
     "plt.xlabel(\"probability of defect occurring in O-ring\");"
    ]


### PR DESCRIPTION
'normed' property returns Attribute Error!
new implementation of matplotlib.pyplot uses 'density' property instead of 'normed' in plt.hist