### PR TITLE
Fix showcase_loss text definition

### DIFF
--- a/Chapter5_LossFunctions/Ch5_LossFunctions_PyMC2.ipynb
+++ b/Chapter5_LossFunctions/Ch5_LossFunctions_PyMC2.ipynb
@@ -322,7 +322,7 @@
     "        elif abs(true_price - guess) <= 250:\n",
     "            return -2*np.abs(true_price)\n",
     "        else:\n",
-    "            return np.abs(true_price - guess - 250)\n",
+    "            return np.abs(true_price - guess)\n",
     "\n",
     "where `risk` is a parameter that defines of how bad it is if your guess is over the true price. A lower `risk` means that you are more comfortable with the idea of going over. If we do bid under and the difference is less than $250, we receive both prizes (modeled here as receiving twice the original prize). Otherwise, when we bid under the `true_price` we want to be as close as possible, hence the `else` loss is a increasing function of the distance between the guess and true price."
    ]

--- a/Chapter5_LossFunctions/Ch5_LossFunctions_PyMC3.ipynb
+++ b/Chapter5_LossFunctions/Ch5_LossFunctions_PyMC3.ipynb
@@ -325,7 +325,7 @@
     "        elif abs(true_price - guess) <= 250:\n",
     "            return -2*np.abs(true_price)\n",
     "        else:\n",
-    "            return np.abs(true_price - guess - 250)\n",
+    "            return np.abs(true_price - guess)\n",
     "\n",
     "where `risk` is a parameter that defines of how bad it is if your guess is over the true price. A lower `risk` means that you are more comfortable with the idea of going over. If we do bid under and the difference is less than $250, we receive both prizes (modeled here as receiving twice the original prize). Otherwise, when we bid under the `true_price` we want to be as close as possible, hence the `else` loss is a increasing function of the distance between the guess and true price."
    ]

--- a/Chapter5_LossFunctions/Ch5_LossFunctions_TFP.ipynb
+++ b/Chapter5_LossFunctions/Ch5_LossFunctions_TFP.ipynb
@@ -771,7 +771,7 @@
         "    elif abs(true_price - guess) <= 250:\n",
         "        return -2*np.abs(true_price)\n",
         "    else:\n",
-        "        return np.abs(true_price - guess - 250)\n",
+        "        return np.abs(true_price - guess)\n",
         "```\n",
         "\n",
         "where `risk` is a parameter that defines of how bad it is if your guess is over the true price. A lower `risk` means that you are more comfortable with the idea of going over. If we do bid under and the difference is less than $250, we receive both prizes (modeled here as receiving twice the original prize). Otherwise, when we bid under the `true_price` we want to be as close as possible, hence the `else` loss is a increasing function of the distance between the guess and true price."


### PR DESCRIPTION
The text definition shows
```python
return np.abs(true_price - guess - 250)
```
yet when the function is actually defined, below, it says
```python
loss[~ix] = np.abs(guess - true_price[~ix])
```