### PR TITLE
fix: Subplot in Chapter 1 gives Matplotlib warning

### DIFF
--- a/Chapter1_Introduction/Ch1_Introduction_PyMC2.ipynb
+++ b/Chapter1_Introduction/Ch1_Introduction_PyMC2.ipynb
@@ -205,7 +205,7 @@
     "\n",
     "# For the already prepared, I'm using Binomial's conj. prior.\n",
     "for k, N in enumerate(n_trials):\n",
-    "    sx = plt.subplot(len(n_trials) / 2, 2, k + 1)\n",
+    "    sx = plt.subplot(int(len(n_trials) / 2), 2, k + 1)\n",
     "    plt.xlabel(\"$p$, probability of heads\") \\\n",
     "        if k in [0, len(n_trials) - 1] else None\n",
     "    plt.setp(sx.get_yticklabels(), visible=False)\n",

--- a/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb
+++ b/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb
@@ -209,7 +209,7 @@
     "\n",
     "# For the already prepared, I'm using Binomial's conj. prior.\n",
     "for k, N in enumerate(n_trials):\n",
-    "    sx = plt.subplot(len(n_trials)/2, 2, k+1)\n",
+    "    sx = plt.subplot(int(len(n_trials)/2), 2, k+1)\n",
     "    plt.xlabel(\"$p$, probability of heads\") \\\n",
     "        if k in [0, len(n_trials)-1] else None\n",
     "    plt.setp(sx.get_yticklabels(), visible=False)\n",

--- a/Chapter1_Introduction/Ch1_Introduction_Pyro.ipynb
+++ b/Chapter1_Introduction/Ch1_Introduction_Pyro.ipynb
@@ -166,7 +166,7 @@
     "\n",
     "# For the already prepared, I'm using Binomial's conj. prior.\n",
     "for k, N in enumerate(n_trials):\n",
-    "    sx = plt.subplot(len(n_trials)/2, 2, k+1)\n",
+    "    sx = plt.subplot(int(len(n_trials)/2), 2, k+1)\n",
     "    plt.xlabel(\"$p$, probability of heads\") \\\n",
     "        if k in [0, len(n_trials)-1] else None\n",
     "    plt.setp(sx.get_yticklabels(), visible=False)\n",

--- a/Chapter1_Introduction/Ch1_Introduction_TFP.ipynb
+++ b/Chapter1_Introduction/Ch1_Introduction_TFP.ipynb
@@ -437,7 +437,7 @@
         "# For the already prepared, I'm using Binomial's conj. prior.\n",
         "plt.figure(figsize(16, 9))\n",
         "for i in range(len(num_trials)):\n",
-        "    sx = plt.subplot(len(num_trials)/2, 2, i+1)\n",
+        "    sx = plt.subplot(int(len(num_trials)/2), 2, i+1)\n",
         "    plt.xlabel(\"$p$, probability of heads\") \\\n",
         "    if i in [0, len(num_trials)-1] else None\n",
         "    plt.setp(sx.get_yticklabels(), visible=False)\n",


### PR DESCRIPTION
Fix a Matplotlib 3.3 deprecation warning in the beginning of the Chapter 1 notebooks.

The exact warning is:

> MatplotlibDeprecationWarning: Passing non-integers as three-element position specification is deprecated since 3.3 and will be removed two minor releases later.

![image](https://user-images.githubusercontent.com/3322228/108939457-c076b180-761f-11eb-94a5-b66f835f2766.png)

The simple fix is done by casting the value from `float` to `int`. Since it's the first chapter it's particularly important to keep it clean.
