### PR TITLE
Add Kaggle Badge

### DIFF
--- a/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb
+++ b/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb
@@ -8,6 +8,7 @@
     "=====\n",
     "and Bayesian Methods for Hackers \n",
     "========\n",
+    "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/blob/master/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>&nbsp;",
     "\n",
     "##### Version 0.1\n",
     "\n",


### PR DESCRIPTION
Add Kaggle Badge that allows for opening the .ipynb as a Kaggle Notebook as seen here [https://www.kaggle.com/product-feedback/152480](https://www.kaggle.com/product-feedback/152480).