### PR TITLE
Step as keyword to avoid: type error

### DIFF
--- a/Chapter3_MCMC/Ch3_IntroMCMC_PyMC_current.ipynb
+++ b/Chapter3_MCMC/Ch3_IntroMCMC_PyMC_current.ipynb
@@ -1290,7 +1290,7 @@
     "    x = pm.Normal(\"x\", mu=4, tau=10)\n",
     "    y = pm.Deterministic(\"y\", 10 - x)\n",
     "\n",
-    "    trace_2 = pm.sample(10000, pm.Metropolis(),chains=1)\n",
+    "    trace_2 = pm.sample(10000, step=pm.Metropolis(), chains=1)\n",
     "\n",
     "plt.plot(trace_2.posterior.x.T)\n",
     "plt.plot(trace_2.posterior.y.T)\n",


### PR DESCRIPTION
Fixing: TypeError: sample() takes from 0 to 1 positional arguments but 2 positional arguments (and 1 keyword-only argument) were given