### PR TITLE
Fixed indexing of trace to avoid shape error

### DIFF
--- a/Chapter3_MCMC/Ch3_IntroMCMC_PyMC_current.ipynb
+++ b/Chapter3_MCMC/Ch3_IntroMCMC_PyMC_current.ipynb
@@ -917,7 +917,7 @@
     "plt.plot(x, center_trace_before25000[1,:], label=\"previous trace of center 1\",\n",
     "     lw=lw, alpha=0.4, c=colors[0])\n",
     "\n",
-    "x = np.arange(25000, 50000)\n",
+    "x = np.arange(25000, 55000)\n",
     "plt.plot(x, center_trace_after_25000[0,: ], label=\"new trace of center 0\", lw=lw, c=\"#348ABD\")\n",
     "plt.plot(x, center_trace_after_25000[1,: ], label=\"new trace of center 1\", lw=lw, c=\"#A60628\")\n",
     "\n",


### PR DESCRIPTION
Wrong shape for plotting center_trace_after (30000 samples vs. 25000 indices)